### PR TITLE
New themes for 'nvim-cokeline' and 'feline.nvim'

### DIFF
--- a/lua/plugins/ui.lua
+++ b/lua/plugins/ui.lua
@@ -307,63 +307,91 @@ feline.setup({
 -- }}}
 
 -- nvim-cokeline setting - bufferline {{{
+local status_ok, cokeline = pcall(require, "cokeline")
+if not status_ok then
+	print("cokeline not loaded!")
+	return
+end
+
 local get_hex = require("cokeline/utils").get_hex
 
-local green = vim.g.terminal_color_2
-local yellow = vim.g.terminal_color_3
+local red = vim.g.terminal_color_1
+local yellow = "#ffccb2"
+local space = { text = " " }
+local dark = get_hex("Normal", "bg")
+local text = get_hex("Comment", "fg")
+local grey = get_hex("ColorColumn", "bg")
+local light = get_hex("Comment", "fg")
+local purple = "#aaaaff"
+local high = "#e2c792"
+local white = "#F5F5F5"
 
-require("cokeline").setup({
+cokeline.setup({
 	default_hl = {
 		fg = function(buffer)
-			return buffer.is_focused and get_hex("Normal", "fg") or get_hex("Conceal", "fg")
+			if buffer.is_focused then
+				return purple
+			end
+			return light
 		end,
-		bg = get_hex("FloatermBorder", "bg"),
+		bg = get_hex("TabLineFill", "bg"),
 	},
-
 	components = {
 		{
 			text = "｜",
 			fg = function(buffer)
-				return buffer.is_modified and yellow or green
+				return buffer.is_modified and yellow or light
 			end,
+			bg = get_hex("TabLineFill", "bg"),
 		},
 		{
 			text = function(buffer)
-				return buffer.devicon.icon .. " "
-			end,
-			fg = function(buffer)
-				return buffer.devicon.color
-			end,
-		},
-		{
-			text = function(buffer)
-				return buffer.index .. ": "
-			end,
-		},
-		{
-			text = function(buffer)
-				return buffer.unique_prefix
-			end,
-			fg = get_hex("Comment", "fg"),
-			style = "italic",
-		},
-		{
-			text = function(buffer)
-				return buffer.filename .. " "
+				return buffer.devicon.icon
 			end,
 			style = function(buffer)
-				return buffer.is_focused and "bold" or nil
+				if buffer.is_focused then
+					return "bold,underline"
+				end
+				return nil
 			end,
-		},
-		{
-			text = " ",
 		},
 		{
 			text = function(buffer)
-				return buffer.is_modified and "● " or " "
+				return buffer.filename
 			end,
 			fg = function(buffer)
-				return buffer.is_modified and green or nil
+				if buffer.is_focused then
+					return purple
+				end
+			end,
+			style = function(buffer)
+				if buffer.is_focused then
+					return "bold,underline"
+				end
+
+				return nil
+			end,
+		},
+		{
+			text = function(buffer)
+				if buffer.is_modified then
+					return " ✱"
+				end
+
+				return ""
+			end,
+			fg = function(buffer)
+				if buffer.is_focused then
+					return purple
+				end
+			end,
+			truncation = { priority = 1 },
+			style = function(buffer)
+				if buffer.is_focused then
+					return "bold,underline"
+				end
+
+				return nil
 			end,
 		},
 	},

--- a/lua/plugins/ui.lua
+++ b/lua/plugins/ui.lua
@@ -88,16 +88,16 @@ local line_ok, feline = pcall(require, "feline")
 if not line_ok then
 	return
 end
-
+local get_col = require("cokeline/utils").get_hex
 local bamboo = {
 	fg = "#c7dab9",
 	bg = "#2f312c",
-	bg3 = "#3a3d37",
-	light_grey = "#838781",
-	green = "#8fb573",
-	yellow = "#ffccb2",
+	bg3 = get_col("TabLineFill", "bg"),
+	light_grey = get_col("Comment", "fg"),
+	green = get_col("String", "fg"),
+	yellow = get_col("Type", "fg"),
 	purple = "#aaaaff",
-	orange = "#ff9966",
+	orange = get_col("WarningMsg", "fg"),
 	light_yellow = "#e2c792",
 	coral = "#f08080",
 	dark_blue = "#758094",

--- a/lua/plugins/ui.lua
+++ b/lua/plugins/ui.lua
@@ -97,18 +97,20 @@ local bamboo = {
 	green = get_col("String", "fg"),
 	yellow = get_col("DiagnosticWarn", "fg"),
 	purple = get_col("DiagnosticHint", "fg"),
+	red = get_col("DiagnosticError", "fg"),
+	cyan = get_col("DiagnosticInfo", "fg"),
 	orange = get_col("WarningMsg", "fg"),
 	coral = get_col("ErrorMsg", "fg"),
 	blue = get_col("Function", "fg"),
 }
 local vi_mode_colors = {
-	NORMAL = "green",
+	NORMAL = "blue",
 	OP = "green",
-	INSERT = "yellow",
-	VISUAL = "purple",
+	INSERT = "green",
+	VISUAL = "orange",
 	LINES = "orange",
 	BLOCK = "coral",
-	REPLACE = "coral",
+	REPLACE = "red",
 	COMMAND = "grey",
 }
 
@@ -224,7 +226,7 @@ local c = {
 	line_percentage = {
 		provider = "line_percentage",
 		hl = {
-			fg = "blue",
+			fg = "cyan",
 			style = "bold",
 		},
 		left_sep = "block",

--- a/lua/plugins/ui.lua
+++ b/lua/plugins/ui.lua
@@ -314,14 +314,17 @@ require("cokeline").setup({
 		fg = function(buffer)
 			return buffer.is_focused and get_hex("Normal", "fg") or get_hex("Conceal", "fg")
 		end,
-		bg = get_hex("FloatermBorder", "bg"),
+		bg = get_hex("TabLineFill", "bg"),
 	},
 
 	components = {
 		{
-			text = "｜",
+			text = " ",
 			fg = function(buffer)
-				return buffer.is_modified and get_hex("Constant", "fg") or get_hex("Conceal", "fg")
+				return buffer.is_modified and get_hex("WarningMsg", "fg") or nil
+			end,
+			style = function(buffer)
+				return buffer.is_modified and "bold,underline" or "underline"
 			end,
 		},
 		{
@@ -329,7 +332,10 @@ require("cokeline").setup({
 				return buffer.devicon.icon .. " "
 			end,
 			fg = function(buffer)
-				return buffer.is_modified and get_hex("Constant", "fg") or nil
+				return buffer.is_modified and get_hex("WarningMsg", "fg") or nil
+			end,
+			style = function(buffer)
+				return buffer.is_modified and "bold,underline" or "underline"
 			end,
 		},
 		{
@@ -337,38 +343,31 @@ require("cokeline").setup({
 				return buffer.index .. ": "
 			end,
 			fg = function(buffer)
-				return buffer.is_modified and get_hex("Constant", "fg") or nil
+				return buffer.is_modified and get_hex("WarningMsg", "fg") or nil
+			end,
+			style = function(buffer)
+				return buffer.is_focused and "bold,underline" or "underline"
 			end,
 		},
 		{
 			text = function(buffer)
 				return buffer.unique_prefix
 			end,
-			-- fg = get_hex("Comment", "fg"),
-			-- style = "italic",
+			style = function(buffer)
+				return buffer.is_focused and "bold,underline" or "underline"
+			end,
 		},
 		{
 			text = function(buffer)
 				return buffer.filename .. " "
 			end,
 			fg = function(buffer)
-				return buffer.is_modified and get_hex("Constant", "fg") or nil
+				return buffer.is_modified and get_hex("WarningMsg", "fg") or nil
 			end,
 			style = function(buffer)
-				return buffer.is_focused and "bold" or nil
+				return buffer.is_focused and "bold,underline" or "underline"
 			end,
 		},
-		{
-			text = " ",
-		},
-		-- {
-		-- 	text = function(buffer)
-		-- 		return buffer.is_modified and "● " or " "
-		-- 	end,
-		-- 	fg = function(buffer)
-		-- 		return buffer.is_modified and orange or nil
-		-- 	end,
-		-- },
 	},
 })
 -- }}}

--- a/lua/plugins/ui.lua
+++ b/lua/plugins/ui.lua
@@ -307,93 +307,68 @@ feline.setup({
 -- }}}
 
 -- nvim-cokeline setting - bufferline {{{
-local status_ok, cokeline = pcall(require, "cokeline")
-if not status_ok then
-	print("cokeline not loaded!")
-	return
-end
-
 local get_hex = require("cokeline/utils").get_hex
 
-local red = vim.g.terminal_color_1
-local yellow = "#ffccb2"
-local space = { text = " " }
-local dark = get_hex("Normal", "bg")
-local text = get_hex("Comment", "fg")
-local grey = get_hex("ColorColumn", "bg")
-local light = get_hex("Comment", "fg")
-local purple = "#aaaaff"
-local high = "#e2c792"
-local white = "#F5F5F5"
-
-cokeline.setup({
+require("cokeline").setup({
 	default_hl = {
 		fg = function(buffer)
-			if buffer.is_focused then
-				return purple
-			end
-			return light
+			return buffer.is_focused and get_hex("Normal", "fg") or get_hex("Conceal", "fg")
 		end,
-		bg = get_hex("TabLineFill", "bg"),
+		bg = get_hex("FloatermBorder", "bg"),
 	},
+
 	components = {
 		{
 			text = "｜",
 			fg = function(buffer)
-				return buffer.is_modified and yellow or light
-			end,
-			bg = get_hex("TabLineFill", "bg"),
-		},
-		{
-			text = function(buffer)
-				return buffer.devicon.icon
-			end,
-			style = function(buffer)
-				if buffer.is_focused then
-					return "bold,underline"
-				end
-				return nil
+				return buffer.is_modified and get_hex("Constant", "fg") or get_hex("Conceal", "fg")
 			end,
 		},
 		{
 			text = function(buffer)
-				return buffer.filename
+				return buffer.devicon.icon .. " "
 			end,
 			fg = function(buffer)
-				if buffer.is_focused then
-					return purple
-				end
-			end,
-			style = function(buffer)
-				if buffer.is_focused then
-					return "bold,underline"
-				end
-
-				return nil
+				return buffer.is_modified and get_hex("Constant", "fg") or nil
 			end,
 		},
 		{
 			text = function(buffer)
-				if buffer.is_modified then
-					return " ✱"
-				end
-
-				return ""
+				return buffer.index .. ": "
 			end,
 			fg = function(buffer)
-				if buffer.is_focused then
-					return purple
-				end
-			end,
-			truncation = { priority = 1 },
-			style = function(buffer)
-				if buffer.is_focused then
-					return "bold,underline"
-				end
-
-				return nil
+				return buffer.is_modified and get_hex("Constant", "fg") or nil
 			end,
 		},
+		{
+			text = function(buffer)
+				return buffer.unique_prefix
+			end,
+			-- fg = get_hex("Comment", "fg"),
+			-- style = "italic",
+		},
+		{
+			text = function(buffer)
+				return buffer.filename .. " "
+			end,
+			fg = function(buffer)
+				return buffer.is_modified and get_hex("Constant", "fg") or nil
+			end,
+			style = function(buffer)
+				return buffer.is_focused and "bold" or nil
+			end,
+		},
+		{
+			text = " ",
+		},
+		-- {
+		-- 	text = function(buffer)
+		-- 		return buffer.is_modified and "● " or " "
+		-- 	end,
+		-- 	fg = function(buffer)
+		-- 		return buffer.is_modified and orange or nil
+		-- 	end,
+		-- },
 	},
 })
 -- }}}

--- a/lua/plugins/ui.lua
+++ b/lua/plugins/ui.lua
@@ -95,8 +95,8 @@ local bamboo = {
 	bg3 = get_col("Normal", "bg"),
 	grey = get_col("Comment", "fg"),
 	green = get_col("String", "fg"),
-	yellow = get_col("Debug", "fg"),
-	-- purple = get_col("WildMenu", "bg"),
+	yellow = get_col("DiagnosticWarn", "fg"),
+	purple = get_col("DiagnosticHint", "fg"),
 	orange = get_col("WarningMsg", "fg"),
 	coral = get_col("ErrorMsg", "fg"),
 	blue = get_col("Function", "fg"),
@@ -105,7 +105,7 @@ local vi_mode_colors = {
 	NORMAL = "green",
 	OP = "green",
 	INSERT = "yellow",
-	VISUAL = "orange",
+	VISUAL = "purple",
 	LINES = "orange",
 	BLOCK = "coral",
 	REPLACE = "coral",
@@ -156,7 +156,7 @@ local c = {
 	gitDiffChanged = {
 		provider = "git_diff_changed",
 		hl = {
-			fg = "blue",
+			fg = "purple",
 		},
 	},
 	separator = {
@@ -190,7 +190,7 @@ local c = {
 	diagnostic_hints = {
 		provider = "diagnostic_hints",
 		hl = {
-			fg = "blue",
+			fg = "purple",
 		},
 	},
 	diagnostic_info = {
@@ -199,26 +199,11 @@ local c = {
 	lsp_client_names = {
 		provider = "lsp_client_names",
 		hl = {
-			fg = "blue",
-			-- style = "bold",
+			fg = "grey",
 		},
 		left_sep = "block",
 	},
-	file_type = {
-		provider = {
-			name = "file_type",
-			opts = {
-				filetype_icon = true,
-				case = "titlecase",
-			},
-		},
-		hl = {
-			fg = "fg",
-			style = "bold",
-		},
-		left_sep = "block",
-		right_sep = "block",
-	},
+
 	file_encoding = {
 		provider = "file_encoding",
 		hl = {
@@ -232,7 +217,6 @@ local c = {
 		provider = "position",
 		hl = {
 			fg = "green",
-			style = "bold",
 		},
 		left_sep = "block",
 		right_sep = "block",
@@ -246,14 +230,6 @@ local c = {
 		left_sep = "block",
 		right_sep = "block",
 	},
-	-- scroll_bar = {
-	-- 	provider = "scroll_bar",
-	-- 	hl = {
-	-- 		fg = "green",
-	-- 		bg = "bg3",
-	-- 		style = "bold",
-	-- 	},
-	-- },
 }
 -- Start statusline
 local left = {
@@ -275,11 +251,9 @@ local middle = {
 }
 
 local right = {
-	-- c.file_type,
 	c.file_encoding,
 	c.position,
 	c.line_percentage,
-	-- c.scroll_bar,
 }
 
 local components = {

--- a/lua/plugins/ui.lua
+++ b/lua/plugins/ui.lua
@@ -90,30 +90,26 @@ if not line_ok then
 end
 local get_col = require("cokeline/utils").get_hex
 local bamboo = {
-	fg = "#c7dab9",
-	bg = "#2f312c",
-	bg3 = get_col("TabLineFill", "bg"),
-	light_grey = get_col("Comment", "fg"),
+	fg = get_col("Pmenu", "fg"),
+	bg = get_col("TabLineFill", "bg"),
+	bg3 = get_col("Normal", "bg"),
+	grey = get_col("Comment", "fg"),
 	green = get_col("String", "fg"),
-	yellow = get_col("Type", "fg"),
-	purple = "#aaaaff",
+	yellow = get_col("Debug", "fg"),
+	-- purple = get_col("WildMenu", "bg"),
 	orange = get_col("WarningMsg", "fg"),
-	light_yellow = "#e2c792",
-	coral = "#f08080",
-	dark_blue = "#758094",
-
-	dark_coral = "#893f45",
+	coral = get_col("ErrorMsg", "fg"),
+	blue = get_col("Function", "fg"),
 }
-
 local vi_mode_colors = {
 	NORMAL = "green",
 	OP = "green",
 	INSERT = "yellow",
-	VISUAL = "purple",
+	VISUAL = "orange",
 	LINES = "orange",
-	BLOCK = "dark_coral",
+	BLOCK = "coral",
 	REPLACE = "coral",
-	COMMAND = "light_grey",
+	COMMAND = "grey",
 }
 
 local c = {
@@ -139,7 +135,7 @@ local c = {
 	gitBranch = {
 		provider = "git_branch",
 		hl = {
-			fg = "light_yellow",
+			fg = "orange",
 			style = "bold",
 		},
 		left_sep = "block",
@@ -160,7 +156,7 @@ local c = {
 	gitDiffChanged = {
 		provider = "git_diff_changed",
 		hl = {
-			fg = "fg",
+			fg = "blue",
 		},
 	},
 	separator = {
@@ -174,7 +170,7 @@ local c = {
 			},
 		},
 		hl = {
-			fg = "light_grey",
+			fg = "grey",
 		},
 		left_sep = " ",
 		right_sep = " ",
@@ -194,7 +190,7 @@ local c = {
 	diagnostic_hints = {
 		provider = "diagnostic_hints",
 		hl = {
-			fg = "dark_blue",
+			fg = "blue",
 		},
 	},
 	diagnostic_info = {
@@ -203,8 +199,8 @@ local c = {
 	lsp_client_names = {
 		provider = "lsp_client_names",
 		hl = {
-			fg = "light_grey",
-			style = "bold",
+			fg = "blue",
+			-- style = "bold",
 		},
 		left_sep = "block",
 	},
@@ -244,20 +240,20 @@ local c = {
 	line_percentage = {
 		provider = "line_percentage",
 		hl = {
-			fg = "dark_blue",
+			fg = "blue",
 			style = "bold",
 		},
 		left_sep = "block",
 		right_sep = "block",
 	},
-	scroll_bar = {
-		provider = "scroll_bar",
-		hl = {
-			fg = "green",
-			bg = "bg3",
-			style = "bold",
-		},
-	},
+	-- scroll_bar = {
+	-- 	provider = "scroll_bar",
+	-- 	hl = {
+	-- 		fg = "green",
+	-- 		bg = "bg3",
+	-- 		style = "bold",
+	-- 	},
+	-- },
 }
 -- Start statusline
 local left = {
@@ -283,7 +279,7 @@ local right = {
 	c.file_encoding,
 	c.position,
 	c.line_percentage,
-	c.scroll_bar,
+	-- c.scroll_bar,
 }
 
 local components = {


### PR DESCRIPTION
Plugin colors are now configuration independent. Colors are retrieved with the `require(“cokeline/utils”).get_hex` function.